### PR TITLE
define item fn before top-stories-batches

### DIFF
--- a/examples/infinite-orange/src/infinite_orange/hn.clj
+++ b/examples/infinite-orange/src/infinite_orange/hn.clj
@@ -16,6 +16,8 @@
 (defn top-stories []
   (hn-get "topstories.json"))
 
+(defn item [id]
+  (hn-get "item/" id ".json"))
 
 (defn top-stories-batches [batch-size]
   (let [[first-batch & batches] (partition-all batch-size (top-stories))
@@ -24,6 +26,3 @@
       (let [next-batch (first @batches)]
         (swap! batches rest)
         (mapv item next-batch)))))
-
-(defn item [id]
-  (hn-get "item/" id ".json"))


### PR DESCRIPTION
The infitnite-orange example was not working because `item` was defined after the `top-stories-batch` function. This PR changes the order of the `def`s