### PR TITLE
Callback reply support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ function is called with the value received from the source.
 ```
 
 All event handling attributes (like `:on-click` or `:on-change`) are registered as callbacks
-that are sent via the websocket to the server.
+that are sent via the websocket to the server. See `ripley.js` namespace for helpers in creating
+callbacks with more options. You can add debouncing and client side condition and success/failure
+handlers.
 
 See more details and fully working example in the examples folder.
 
@@ -99,6 +101,9 @@ see namespace docstring for an integration source in `ripley.integration.<type>`
 
 
 ## Changes
+
+### 2023-06-10
+- Support client side success and failure callbacks
 
 ### 2023-06-07
 - `ripley.html/compile-special` is now a multimethod and can be extended

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,8 @@
         org.clojure/tools.logging {:mvn/version "1.2.4"}}
  :aliases
  {:dev {:extra-deps {org.clojure/test.check {:mvn/version "1.1.0"}
-                     org.clojars.czan/stateful-check {:mvn/version "0.4.2"}}}
+                     org.clojars.czan/stateful-check {:mvn/version "0.4.2"}
+                     io.github.pfeodrippe/wally {:mvn/version "0.0.4"}}}
   :test {:extra-paths ["test"]
          :extra-deps {com.cognitect/test-runner
                       {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/resources/live-client-template.js
+++ b/resources/live-client-template.js
@@ -29,7 +29,7 @@ window.ripley = {
             }
         }
     },
-    _send: function(id,args) {
+    _send: function(id,args,onsuccess,onfailure) {
         if(this.type === "sse") {
             var l = window.location;
             fetch(l.protocol+"//"+l.host+this.cpath+"?id="+this.cid,
@@ -58,7 +58,7 @@ window.ripley = {
         let c = this.connection;
         for(var i = 0; i<q.length; i++) {
             let cb = q[i];
-            this.send(cb.id, cb.args);
+            this.send(cb.id, cb.args, undefined, cb.onsuccess, cb.onfailure);
         }
         // clear the array
         q.length = 0;

--- a/resources/live-client-template.js
+++ b/resources/live-client-template.js
@@ -40,10 +40,10 @@ window.ripley = {
             let cid;
             let msg;
             if(onsuccess !== undefined || onfailure !== undefined) {
-                cid = nextCallbackId;
-                nextCallbackId++;
-                msg = [id, args, cid];
-                callbackHandlers[cid] = {onsuccess: onsuccess, onfailure: onfailure};
+                cid = this.nextCallbackId;
+                this.nextCallbackId++;
+                msg = [id, args, cid, onsuccess !== undefined ? 1 : 0, onfailure !== undefined ? 1 : 0];
+                this.callbackHandlers[cid] = {onsuccess: onsuccess, onfailure: onfailure};
             } else {
                 msg = [id, args];
             }
@@ -178,14 +178,14 @@ window.ripley = {
         };
     },
     handleResult: function(type, replyId, reply) {
-        let handlers = callbackHandlers[replyId];
+        let handlers = this.callbackHandlers[replyId];
         if(handlers !== undefined) {
             let handle = handlers[type];
             if(handle !== undefined) {
                 handle(reply);
             }
         }
-        delete callbackHandlers[replyId];
+        delete this.callbackHandlers[replyId];
     }
 }
 

--- a/resources/live-client-template.js
+++ b/resources/live-client-template.js
@@ -42,7 +42,7 @@ window.ripley = {
             if(onsuccess !== undefined || onfailure !== undefined) {
                 cid = this.nextCallbackId;
                 this.nextCallbackId++;
-                msg = [id, args, cid, onsuccess !== undefined ? 1 : 0, onfailure !== undefined ? 1 : 0];
+                msg = [id, args, cid];
                 this.callbackHandlers[cid] = {onsuccess: onsuccess, onfailure: onfailure};
             } else {
                 msg = [id, args];
@@ -184,8 +184,8 @@ window.ripley = {
             if(handle !== undefined) {
                 handle(reply);
             }
+            delete this.callbackHandlers[replyId];
         }
-        delete this.callbackHandlers[replyId];
     }
 }
 

--- a/src/ripley/html.clj
+++ b/src/ripley/html.clj
@@ -121,10 +121,8 @@
     (let [invoke-callback-js (str "_rs("
                                   (p/register-callback! dynamic/*live-context*
                                                         (p/callback-fn callback))
-                                  ",[" (str/join "," (p/callback-js-params callback)) "],"
-                                  (if-let [debounce-ms (p/callback-debounce-ms callback)]
-                                    (str debounce-ms)
-                                    "undefined")
+                                  ",[" (str/join "," (p/callback-js-params callback)) "]"
+                                  "," (or (p/callback-debounce-ms callback) "undefined")
                                   "," (or (p/callback-on-success callback) "undefined")
                                   "," (or (p/callback-on-failure callback) "undefined")
                                   ")")

--- a/src/ripley/html.clj
+++ b/src/ripley/html.clj
@@ -121,9 +121,12 @@
     (let [invoke-callback-js (str "_rs("
                                   (p/register-callback! dynamic/*live-context*
                                                         (p/callback-fn callback))
-                                  ",[" (str/join "," (p/callback-js-params callback)) "]"
-                                  (when-let [debounce-ms (p/callback-debounce-ms callback)]
-                                    (str "," debounce-ms))
+                                  ",[" (str/join "," (p/callback-js-params callback)) "],"
+                                  (if-let [debounce-ms (p/callback-debounce-ms callback)]
+                                    (str debounce-ms)
+                                    "undefined")
+                                  "," (or (p/callback-on-success callback) "undefined")
+                                  "," (or (p/callback-on-failure callback) "undefined")
                                   ")")
           condition (p/callback-condition callback)]
       (if condition

--- a/src/ripley/js.clj
+++ b/src/ripley/js.clj
@@ -4,23 +4,28 @@
             [ripley.impl.dynamic :as dyn]
             [ripley.html :as h]))
 
-(defrecord JSCallback [callback-fn condition js-params debounce-ms]
+(defrecord JSCallback [callback-fn condition js-params debounce-ms
+                       on-success on-failure]
   p/Callback
   (callback-js-params [_] js-params)
   (callback-fn [_] callback-fn)
   (callback-debounce-ms [_] debounce-ms)
-  (callback-condition [_] condition))
+  (callback-condition [_] condition)
+  (callback-on-success [_] on-success)
+  (callback-on-failure [_] on-failure))
 
 
 (defn js
   "Create a JavaScript callback that evaluates JS in browser to get parameters"
   [callback-fn & js-params]
-  (->JSCallback callback-fn nil js-params nil))
+  (map->JSCallback {:callback-fn callback-fn :js-params js-params}))
 
 (defn js-when
   "Create a conditionally fired JS callback."
   [js-condition callback-fn & js-params]
-  (->JSCallback callback-fn js-condition js-params nil))
+  (map->JSCallback {:callback-fn callback-fn
+                    :js-condition js-condition
+                    :js-params js-params}))
 
 
 (defn js-debounced
@@ -28,7 +33,9 @@
   changed within given ms). This is useful for input values to prevent
   sending on each keystroke, only when user stops typing."
   [debounce-ms callback-fn & js-params]
-  (->JSCallback callback-fn nil js-params debounce-ms))
+  (map->JSCallback {:callback-fn callback-fn
+                    :js-params js-params
+                    :debounce-ms debounce-ms}))
 
 (defn keycode-pressed?
   "Return JS code for checking if keypress event has given keycode"

--- a/src/ripley/js.clj
+++ b/src/ripley/js.clj
@@ -24,7 +24,7 @@
   "Create a conditionally fired JS callback."
   [js-condition callback-fn & js-params]
   (map->JSCallback {:callback-fn callback-fn
-                    :js-condition js-condition
+                    :condition js-condition
                     :js-params js-params}))
 
 

--- a/src/ripley/js.clj
+++ b/src/ripley/js.clj
@@ -90,3 +90,20 @@
                         identity
                         {:patch :eval-js})]
     (h/html [:script {:data-rl id}])))
+
+(defn- with [callback field value]
+  (map->JSCallback (merge (if (fn? callback)
+                            {:callback-fn callback}
+                            callback)
+                          {field value})))
+(defn on-success
+  "Add JS code that is run after the callback is processed on the server."
+  [callback on-success-js]
+  {:pre [(string? on-success-js)]}
+  (with callback :on-success on-success-js))
+
+(defn on-failure
+  "Add JS code that handles callback failure."
+  [callback on-failure-js]
+  {:pre [(string? on-failure-js)]}
+  (with callback :on-failure on-failure-js))

--- a/src/ripley/live/context.clj
+++ b/src/ripley/live/context.clj
@@ -202,6 +202,11 @@
       (swap! state-atom update :send-queue (fnil conj []) data)
       (send-fn! ch data))))
 
+(defn- empty-context? [{state :state}]
+  (let [{:keys [components callbacks]} @state]
+    (and (empty? components)
+         (empty? callbacks))))
+
 (defn render-with-context
   "Return input stream that calls render-fn with a new live context bound."
   [render-fn]
@@ -221,8 +226,8 @@
              (catch Throwable t
                (println "Exception while rendering!" t))
              (finally
-               (if (empty? (:components @(:state ctx)))
-                 ;; No live components rendered, remove context immediately
+               (if (empty-context? ctx)
+                 ;; No live components  rendered or callbacks registered, remove context immediately
                  (do
                    (log/debug "No live components, remove context with id: " id)
                    (swap! current-live-contexts dissoc id))

--- a/src/ripley/live/patch.clj
+++ b/src/ripley/live/patch.clj
@@ -121,13 +121,13 @@ for(let i=1;i<payload.length;i++) {
   "Callback error handler."
   {:type "CE"
    :render-mode :json
-   :js-eval "ripley.handleResult('onfailure',payload[1], payload[2]);"})
+   :js-eval "ripley.handleResult('onfailure',payload[0], payload[1]);"})
 
 (define-patch-method callback-success
   "Callback success handler."
   {:type "CO"
    :render-mode :json
-   :js-eval "ripley.handleResult('onsuccess',payload[1], payload[2]);"})
+   :js-eval "ripley.handleResult('onsuccess',payload[0], payload[1]);"})
 
 (def live-client-script
   (delay

--- a/src/ripley/live/patch.clj
+++ b/src/ripley/live/patch.clj
@@ -117,6 +117,18 @@ for(let i=1;i<payload.length;i++) {
    :render-mode :json
    :js-eval "ripley.T(elt,payload);"})
 
+(define-patch-method callback-error
+  "Callback error handler."
+  {:type "CE"
+   :render-mode :json
+   :js-eval "ripley.handleResult('onfailure',payload[1], payload[2]);"})
+
+(define-patch-method callback-success
+  "Callback success handler."
+  {:type "CO"
+   :render-mode :json
+   :js-eval "ripley.handleResult('onsuccess',payload[1], payload[2]);"})
+
 (def live-client-script
   (delay
     (-> "live-client-template.js" io/resource slurp

--- a/src/ripley/live/protocols.clj
+++ b/src/ripley/live/protocols.clj
@@ -45,4 +45,10 @@ Returns 0-arity function that will remove the listener when called.")
   (callback-js-params [this] "Return collection JS code fragments to get parameters")
   (callback-debounce-ms [this] "Return milliseconds how much this callback invocation should be debounced for, or nil if not debounced.")
   (callback-fn [this] "Return the actual callback function to invoke.")
-  (callback-condition [this] "Return JS condition code for conditional callback invocation ornil"))
+  (callback-condition [this] "Return JS condition code for conditional callback invocation or nil")
+  (callback-on-success [this]
+    "Return JS function code to call when server callback has succeeded. The function will be called
+    with the return value of the server side function (which must be JSON serializable).")
+  (callback-on-failure [this]
+    "Return JS function code to call when server callback has failed. The function will be called
+   with the original arguments of the callback and an object describing the error."))

--- a/test/ripley/browser_test.clj
+++ b/test/ripley/browser_test.clj
@@ -85,4 +85,4 @@
 
     (is (str/blank? (w/text-content :error)))
     (w/click :do)
-    (is (.getByText @page "nope"))))
+    (is (w/wait-for (ws/text "nope")))))

--- a/test/ripley/browser_test.clj
+++ b/test/ripley/browser_test.clj
@@ -1,0 +1,58 @@
+(ns ripley.browser-test
+  "Test with playwright. Runs a test server on port 4455."
+  (:require [org.httpkit.server :as server]
+            [ripley.live.context :as context]
+            [ripley.html :as h]
+            [wally.main :as w]
+            [wally.selectors :as ws]
+            [ripley.live.source :as source]
+            [clojure.test :refer [deftest is testing] :as t]))
+
+(defonce page (w/make-page {:headless true}))
+
+(defonce test-component
+  (atom #(h/html [:div "nothing to test"])))
+
+(t/use-fixtures :once #(w/with-page page (%)))
+
+(let [ws-handler (context/connection-handler "/ws")]
+  (defn page-handler [{uri :uri :as req}]
+    (if (= uri "/ws")
+      (ws-handler req)
+      (h/render-response
+       #(do (h/out! "<!DOCTYPE html>\n")
+            (h/html
+             [:html
+              [:head
+               [:meta {:charset "UTF-8"}]
+               (h/live-client-script "/ws")]
+              [:body (@test-component)]]))))))
+
+(defonce test-server
+  (server/run-server page-handler {:port 4455}))
+
+(defmacro with-page
+  [page & test-body]
+
+  `(do
+     (reset! test-component (fn [] ~page))
+     (w/navigate "http://localhost:4455/")
+     ~@test-body))
+
+
+(deftest counter-page
+  (with-page
+    (let [[?count _set-count! swap-count!] (source/use-state 0)]
+      (h/html
+       [:div
+        [::h/live ?count
+         #(h/html
+           [:div.counter "Clicked " % " times."])]
+        [:button.inc {:on-click #(swap-count! inc)}
+         "click me"]]))
+
+    (is (w/wait-for (ws/text "Clicked 0 times.")))
+    (w/click :inc)
+    (is (w/wait-for (ws/text "Clicked 1 times.")))
+    (w/click :inc)
+    (is (w/wait-for (ws/text "Clicked 2 times.")))))


### PR DESCRIPTION
Support adding `on-success` and `on-failure` callbacks on the client side.

If an on-success is provided, the return value is sent to the client and the callback invoked with it. The return value of the server callback function must be serializable to JSON.

If an on-failure is provided, any throwable thrown during server callback invocation is caught and send to the client as a JSON object with `message` key containing the message and any context.

Added Playwright tests for both.