### PR TITLE
Add unlisten cleanup for live collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,11 @@ or db connection pools). The set of vars to capture must be configured when call
 
 ## Changes
 
+### 2023-09-20
+- Bugfix: proper live collection cleanup on long-lived source (like atom)
+
 ### 2023-09-19
 - Bugfix: support 0-arity callbacks when wrapping failure/success handlers
-- Bugfix: proper collection cleanup on long-lived source (like atom)
 
 ### 2023-09-16
 - Alternate server implementation support (with pedestal+jetty implementation)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ or db connection pools). The set of vars to capture must be configured when call
 
 ### 2023-09-19
 - Bugfix: support 0-arity callbacks when wrapping failure/success handlers
+- Bugfix: proper collection cleanup on long-lived source (like atom)
+
 ### 2023-09-16
 - Alternate server implementation support (with pedestal+jetty implementation)
 

--- a/src/ripley/live/collection.clj
+++ b/src/ripley/live/collection.clj
@@ -168,13 +168,9 @@
 
     (log/debug "Initial collection: " (count initial-collection) "items")
     (aset unlisten-fn 0
-          (let [unlisten
-                (listen-collection!
-                 source item-source-fn initial-collection collection-id
-                 key render components-by-key)]
-            #(do
-               (println "unlisten for " collection-id (RuntimeException.))
-               (unlisten))))
+          (listen-collection!
+           source item-source-fn initial-collection collection-id
+           key render components-by-key))
 
     (h/out! "<" container-element-name
             (when (seq container-element-classes)

--- a/src/ripley/live/collection.clj
+++ b/src/ripley/live/collection.clj
@@ -34,87 +34,89 @@
       (p/listen!
        source
        (fn collection-source-listener [new-collection]
-         (log/debug "New collection:" (count new-collection) "items")
-         (let [{old-collection-by-key :by-key
-                old-collection-keys :keys} @old-state
+         (try
+           (log/debug "New collection:" (count new-collection) "items for collection id " collection-id)
+           (let [{old-collection-by-key :by-key
+                  old-collection-keys :keys} @old-state
 
-               new-collection-by-key (by-key new-collection)
-               new-collection-keys (map key new-collection)
+                 new-collection-by-key (by-key new-collection)
+                 new-collection-keys (map key new-collection)
 
-               old-key-set (set old-collection-keys)
-               new-key-set (set new-collection-keys)
-               removed-keys (set/difference old-key-set new-key-set)
-               added-keys (set/difference new-key-set old-key-set)
+                 old-key-set (set old-collection-keys)
+                 new-key-set (set new-collection-keys)
+                 removed-keys (set/difference old-key-set new-key-set)
+                 added-keys (set/difference new-key-set old-key-set)
 
-               ;; If list of old keys (minus removed) differs
-               ;; from list of new keys (minus additions), we need
-               ;; to send a child order patch.
-               new-keys-without-added
-               (remove added-keys new-collection-keys)
-
-               order-change
-               (when (not= (remove removed-keys old-collection-keys)
-                           new-keys-without-added)
-                 (patch/child-order collection-id
-                                    (mapv (comp :component-id @components-by-key)
-                                          new-keys-without-added)))
-
-               removed-components (select-keys @components-by-key removed-keys)
-               patches
-               (cond-> []
-                 (seq removed-keys)
-                 (conj (patch/delete-many
-                        (mapv :component-id (vals removed-components))))
+                 ;; If list of old keys (minus removed) differs
+                 ;; from list of new keys (minus additions), we need
+                 ;; to send a child order patch.
+                 new-keys-without-added
+                 (remove added-keys new-collection-keys)
 
                  order-change
-                 (conj order-change))]
+                 (when (not= (remove removed-keys old-collection-keys)
+                             new-keys-without-added)
+                   (patch/child-order collection-id
+                                      (mapv (comp :component-id @components-by-key)
+                                            new-keys-without-added)))
 
-           (reset! old-state {:by-key new-collection-by-key
-                              :keys new-collection-keys})
+                 removed-components (select-keys @components-by-key removed-keys)
+                 patches
+                 (cond-> []
+                   (seq removed-keys)
+                   (conj (patch/delete-many
+                          (mapv :component-id (vals removed-components))))
 
-           ;; Cleanup components that were removed
-           (swap! components-by-key #(reduce dissoc % removed-keys))
-           (doseq [[_ {id :component-id}] removed-components]
-             (p/deregister! ctx id))
+                   order-change
+                   (conj order-change))]
+             (reset! old-state {:by-key new-collection-by-key
+                                :keys new-collection-keys})
 
-           ;; Set child order for existing children (if changed)
-           ;; and add any new ones
-           (loop [prev-key nil
-                  [new-key & new-keys] new-collection-keys
-                  patches patches]
-             (if-not new-key
-               (when (seq patches)
-                 (p/send! ctx patches))
+             ;; Cleanup components that were removed
+             (swap! components-by-key #(reduce dissoc % removed-keys))
+             (doseq [[_ {id :component-id}] removed-components]
+               (p/deregister! ctx id))
 
-               (let [old-value (get old-collection-by-key new-key)
-                     new-value (get new-collection-by-key new-key)
-                     set-value!
-                     (when old-value
-                       (:set-value! (@components-by-key new-key)))]
-                 (if-not (added-keys new-key)
-                   (do
-                     ;; Send update if needed to existing item
-                     (when (and (some? old-value)
-                                (not= old-value new-value))
-                       (set-value! new-value))
+             ;; Set child order for existing children (if changed)
+             ;; and add any new ones
+             (loop [prev-key nil
+                    [new-key & new-keys] new-collection-keys
+                    patches patches]
+               (if-not new-key
+                 (when (seq patches)
+                   (p/send! ctx patches))
 
-                     (recur new-key new-keys patches))
+                 (let [old-value (get old-collection-by-key new-key)
+                       new-value (get new-collection-by-key new-key)
+                       set-value!
+                       (when old-value
+                         (:set-value! (@components-by-key new-key)))]
+                   (if-not (added-keys new-key)
+                     (do
+                       ;; Send update if needed to existing item
+                       (when (and (some? old-value)
+                                  (not= old-value new-value))
+                         (set-value! new-value))
 
-                   ;; Added, render this after given prev child id
-                   (let [after-component-id
-                         (when prev-key
-                           (:component-id (@components-by-key prev-key)))
-                         {new-id :component-id :as component}
-                         (create-component ctx item-source-fn render new-value)
-                         rendered (dynamic/with-live-context ctx
-                                    (dynamic/with-component-id new-id
-                                      (render-to-string render new-value)))]
-                     (swap! components-by-key assoc new-key component)
-                     (recur new-key new-keys
-                            (conj patches
-                                  (if after-component-id
-                                    (patch/insert-after after-component-id rendered)
-                                    (patch/prepend collection-id rendered)))))))))))))))
+                       (recur new-key new-keys patches))
+
+                     ;; Added, render this after given prev child id
+                     (let [after-component-id
+                           (when prev-key
+                             (:component-id (@components-by-key prev-key)))
+                           {new-id :component-id :as component}
+                           (create-component ctx item-source-fn render new-value)
+                           rendered (dynamic/with-live-context ctx
+                                      (dynamic/with-component-id new-id
+                                        (render-to-string render new-value)))]
+                       (swap! components-by-key assoc new-key component)
+                       (recur new-key new-keys
+                              (conj patches
+                                    (if after-component-id
+                                      (patch/insert-after after-component-id rendered)
+                                      (patch/prepend collection-id rendered))))))))))
+           (catch Throwable t
+             (log/error t "Exception in collection listener"))))))))
 
 (defn live-collection
   "Render a live-collection that automatically inserts and removes
@@ -151,9 +153,11 @@
 
         initial-collection (p/current-value source)
 
+        unlisten-fn (object-array 1)
         ;; Register dummy component as parent, that has no render and will never receive updates
-        collection-id (p/register! ctx nil :_ignore {})
-
+        collection-id (p/register! ctx nil :_ignore {:cleanup #(do
+                                                                 (println "unlisten called!")
+                                                                 ((aget unlisten-fn 0)))})
 
         ;; Store individual :source and :component-id for entities
         components-by-key
@@ -165,9 +169,14 @@
         container-element-classes (h/element-class-names container-element)]
 
     (log/debug "Initial collection: " (count initial-collection) "items")
-    (listen-collection!
-     source item-source-fn initial-collection collection-id
-     key render components-by-key)
+    (aset unlisten-fn 0
+          (let [unlisten
+                (listen-collection!
+                 source item-source-fn initial-collection collection-id
+                 key render components-by-key)]
+            #(do
+               (println "unlisten for " collection-id (RuntimeException.))
+               (unlisten))))
 
     (h/out! "<" container-element-name
             (when (seq container-element-classes)

--- a/src/ripley/live/collection.clj
+++ b/src/ripley/live/collection.clj
@@ -155,9 +155,7 @@
 
         unlisten-fn (object-array 1)
         ;; Register dummy component as parent, that has no render and will never receive updates
-        collection-id (p/register! ctx nil :_ignore {:cleanup #(do
-                                                                 (println "unlisten called!")
-                                                                 ((aget unlisten-fn 0)))})
+        collection-id (p/register! ctx nil :_ignore {:cleanup #((aget unlisten-fn 0))})
 
         ;; Store individual :source and :component-id for entities
         components-by-key


### PR DESCRIPTION
As live-collection is not registered with a source, but the source listener is added separately, it is not subject to automatic unlisten when cleaning up. We need to add a separate cleanup that removes source listener.

This is only a problem with long-lived sources (like an atom) that multiple pages might be listening to.